### PR TITLE
Allow building with other versions of Cython

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,5 @@ include LICENSE
 include deps/*.tar.gz
 recursive-include tests *.py
 include tox.ini
+include jq.pyx
+include jq.c

--- a/makefile
+++ b/makefile
@@ -15,7 +15,6 @@ clean:
 	rm -rf dist
 
 bootstrap: _virtualenv jq.c
-	_virtualenv/bin/pip install -e .
 ifneq ($(wildcard test-requirements.txt),)
 	_virtualenv/bin/pip install -r test-requirements.txt
 endif
@@ -28,5 +27,4 @@ _virtualenv:
 	_virtualenv/bin/pip install --upgrade wheel
 
 jq.c: _virtualenv jq.pyx
-	_virtualenv/bin/pip install cython==3.0.10
-	_virtualenv/bin/cython jq.pyx
+	_virtualenv/bin/pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,13 +2,10 @@
 requires = [
     "setuptools>=43",
     "wheel",
+    "Cython==3.0.10",
 ]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-before-build = [
-    "pip install cython==3.0.10",
-    "cython {project}/jq.pyx",
-]
 test-requires = "-r test-requirements.txt"
 test-command = "pytest {project}/tests"

--- a/setup.py
+++ b/setup.py
@@ -94,14 +94,26 @@ else:
         os.path.join(jq_lib_dir, "modules/oniguruma/src/.libs/libonig.a"),
     ]
 
+
+try:
+    # Follow recommendation from https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#distributing-cython-modules
+    from Cython.Build import cythonize
+except ImportError:
+    cythonize = lambda o: o
+    ext = ".c"
+else:
+    ext = ".pyx"
+
+
 jq_extension = Extension(
     "jq",
-    sources=["jq.c"],
+    sources=[_path_in_dir(f"jq{ext}")],
     define_macros=[("MS_WIN64" , 1)] if os.name == "nt" and sys.maxsize > 2**32  else None, # https://github.com/cython/cython/issues/2670
     include_dirs=[os.path.join(jq_lib_dir, "src")],
     extra_link_args=["-lm"] + (["-Wl,-Bstatic", "-lpthread", "-lshlwapi", "-static-libgcc"] if os.name == 'nt' else []) + link_args_deps,
     extra_objects=extra_objects,
 )
+
 
 setup(
     name='jq',
@@ -112,7 +124,7 @@ setup(
     url='https://github.com/mwilliamson/jq.py',
     python_requires='>=3.6',
     license='BSD 2-Clause',
-    ext_modules = [jq_extension],
+    ext_modules = cythonize([jq_extension]),
     cmdclass={"build_ext": jq_build_ext},
     classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 import os
 import shlex
 import shutil
+import struct
 import subprocess
 import sys
 import sysconfig
@@ -105,10 +106,13 @@ else:
     ext = ".pyx"
 
 
+_64_BIT_INTERPRETER = struct.calcsize("P") != 4 # From https://github.com/pypa/packaging/pull/711
+
+
 jq_extension = Extension(
     "jq",
     sources=[_path_in_dir(f"jq{ext}")],
-    define_macros=[("MS_WIN64" , 1)] if os.name == "nt" and sys.maxsize > 2**32  else None, # https://github.com/cython/cython/issues/2670
+    define_macros=[("MS_WIN64" , "1")] if os.name == "nt" and _64_BIT_INTERPRETER else None, # https://github.com/cython/cython/issues/2670
     include_dirs=[os.path.join(jq_lib_dir, "src")],
     extra_link_args=["-lm"] + (["-Wl,-Bstatic", "-lpthread", "-lshlwapi", "-static-libgcc"] if os.name == 'nt' else []) + link_args_deps,
     extra_objects=extra_objects,


### PR DESCRIPTION
Since https://github.com/cython/cython/pull/6201 was merged the Cython docs make it clearer that sdists should ship the pyx files, because the generated C files may or may not work on all interpreters and interpreter versions. This applies to GraalPy, where the C code in the 1.8.0 sdist of jq compiles, but then crashes at runtime in some scenarios.